### PR TITLE
Fix NPM publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
   "name": "@pepabo-inhouse/flippers-flavor",
   "description": "Flippers flavor for Inhouse Components Web",
   "version": "0.0.0",
-  "publishConfig": {
-    "registry": "https://npm.git.pepabo.com/"
-  },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/pepabo/flippers-flavor.git"
+    "url": "https://github.com/pepabo/flippers-flavor.git"
   },
   "dependencies": {
     "@pepabo-inhouse/tokens": "^0.14.0"


### PR DESCRIPTION
To publish as NPM public package, URL should be fixed.