### PR TITLE
Tokensが更新されたのでFlavorもバージョンアップします

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "url": "https://github.com/pepabo/flippers-flavor.git"
   },
   "dependencies": {
-    "@pepabo-inhouse/tokens": "^0.14.0"
+    "@pepabo-inhouse/tokens": "^0.16.0"
   }
 }


### PR DESCRIPTION
Flippers Color v3確定に伴い、Flippers Tokensのカラー情報を更新しました。
そのため、Flavorで利用しているTokensパッケージのバージョン情報も更新します。