### PR TITLE
最新のTokensを読み込みます

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "url": "git+https://github.com/pepabo/flippers-flavor.git"
   },
   "dependencies": {
-    "@pepabo-inhouse/tokens": "^0.17.1"
+    "@pepabo-inhouse/tokens": "^2.3.0"
   }
 }


### PR DESCRIPTION
最新のTokenを読み込みます。
https://github.com/pepabo/inhouse-tokens/commits/main?since=2024-09-17&until=2024-11-29 の変更がtokenに入っており、そのうち、flippersに関係する更新は以下です。
- [flippersのgapトークンをspacingに揃えます](https://github.com/pepabo/inhouse-tokens/commit/fdbafca39461c666c53a3a1f19f3b732660a6e05) 
- [color.surface.base.light.primaryおよびdarkにコントラスト比3:1を満たすフォーカスリングのcolorトークンを慣用的なblueから設定](https://github.com/pepabo/inhouse-tokens/commit/5455a4e90fb892e49fc81e6ca46d3e85719d6911)
- [gapトークンを拡張する](https://github.com/pepabo/inhouse-tokens/commit/b02d799f143524d359531f0218b2daf3b2cb49ff)
- [gapの値をspacingから参照しないようにする](https://github.com/pepabo/inhouse-tokens/commit/84a75c62306822116c5155df9d22c0a0e60a66b1)
- [progress-indicatorのborderのサイズ展開をする](https://github.com/pepabo/inhouse-tokens/commit/45d20cb09af8c7a5609d9a66a77bee030649463f)
- [progress-indicatorのborderのサイズ展開をする](https://github.com/pepabo/inhouse-tokens/commit/4dcbe51a5647e81f7a48471e8b3fdf3d9418b577)